### PR TITLE
Keypress listener

### DIFF
--- a/Game.js
+++ b/Game.js
@@ -171,12 +171,12 @@ class Game {
         this.fps = 1000 / dt;
         if (!this.paused && dt <= MAX_DELTA_TIME) {
             this.updateState(dt);
-            if (this.updateOverlay) {
-                this.drawOverlayLayer();
-                this.updateOverlay = false;
-            }
-            this.drawGameLayer();
         }
+        if (this.updateOverlay) {
+            this.drawOverlayLayer();
+            this.updateOverlay = false;
+        }
+        this.drawGameLayer();
         if (this.showDebug) {
             this.drawDebugLayer();
         }

--- a/InputManager.js
+++ b/InputManager.js
@@ -39,15 +39,8 @@ class InputManager {
      */
     keyUp(event) {
         Object.values(this.keyMap).forEach(key => {
-                if (key.matches(event)) {
-                    let isKeyPress = key.isKeyDown;
-                    key.fireKeyUp();
-                    if (isKeyPress) {
-                        key.fireKeyPress();
-                    }
-                }
-            }
-        );
+            key.matches(event) && key.fireKeyUp();
+        });
         InputManager.preventDefaultEventActionIfRequired(event);
     }
 

--- a/InputManager.js
+++ b/InputManager.js
@@ -39,8 +39,15 @@ class InputManager {
      */
     keyUp(event) {
         Object.values(this.keyMap).forEach(key => {
-            key.matches(event) && key.fireKeyUp();
-        });
+                if (key.matches(event)) {
+                    let isKeyPress = key.isKeyDown;
+                    key.fireKeyUp();
+                    if (isKeyPress) {
+                        key.fireKeyPress();
+                    }
+                }
+            }
+        );
         InputManager.preventDefaultEventActionIfRequired(event);
     }
 

--- a/Key.js
+++ b/Key.js
@@ -78,15 +78,17 @@ class Key {
     }
 
     /**
-     * Calls all of the registered keyUp listener callback functions (and all keyPress listener callback functions when
-     * appropriate)
+     * Calls all of the registered keyUp listener callback functions.
      */
     fireKeyUp() {
-        let isKeyPress = this.isKeyDown;
         this.isKeyDown = false;
         this.keyUpListeners.forEach(listener => listener());
-        if (isKeyPress) {
-            this.keyPressListeners.forEach(listener => listener());
-        }
+    }
+
+    /**
+     * Calls all of the registered keyPress listener callback functions.
+     */
+    fireKeyPress() {
+        this.keyPressListeners.forEach(listener => listener());
     }
 }

--- a/Key.js
+++ b/Key.js
@@ -60,10 +60,11 @@ class Key {
      */
     matches(event) {
         return this.key == event.key
-            && this.alt == event.altKey
+            && (event.type == 'keyup'
+            || this.alt == event.altKey
             && this.ctrl == event.ctrlKey
             && this.meta == event.metaKey
-            && this.shift == event.shiftKey;
+            && this.shift == event.shiftKey);
     }
 
     /**

--- a/Key.js
+++ b/Key.js
@@ -14,12 +14,17 @@ class Key {
      */
     constructor(key, alt, ctrl, meta, shift) {
         this.key = key;
+        //noinspection PointlessBooleanExpressionJS
         this.alt = !!alt;
+        //noinspection PointlessBooleanExpressionJS
         this.ctrl = !!ctrl;
+        //noinspection PointlessBooleanExpressionJS
         this.meta = !!meta;
+        //noinspection PointlessBooleanExpressionJS
         this.shift = !!shift;
         this.keyDownListeners = [];
         this.keyUpListeners = [];
+        this.keyPressListeners = [];
         this.isKeyDown = false;
         this.autoRepeatEnabled = false;
     }
@@ -38,6 +43,14 @@ class Key {
      */
     addKeyUpListener(listener) {
         this.keyUpListeners.push(listener);
+    }
+
+    /**
+     * Adds a callback function to the list of callbacks invoked when a keyUp event occurs after a keyDown event.
+     * @param {function} listener the callback
+     */
+    addKeyPressListener(listener) {
+        this.keyPressListeners.push(listener);
     }
 
     /**
@@ -64,10 +77,15 @@ class Key {
     }
 
     /**
-     * Calls all of the registered keyUp listener callback functions.
+     * Calls all of the registered keyUp listener callback functions (and all keyPress listener callback functions when
+     * appropriate)
      */
     fireKeyUp() {
+        let isKeyPress = this.isKeyDown;
         this.isKeyDown = false;
         this.keyUpListeners.forEach(listener => listener());
+        if (isKeyPress) {
+            this.keyPressListeners.forEach(listener => listener());
+        }
     }
 }

--- a/Key.js
+++ b/Key.js
@@ -24,7 +24,6 @@ class Key {
         this.shift = !!shift;
         this.keyDownListeners = [];
         this.keyUpListeners = [];
-        this.keyPressListeners = [];
         this.isKeyDown = false;
         this.autoRepeatEnabled = false;
     }
@@ -43,14 +42,6 @@ class Key {
      */
     addKeyUpListener(listener) {
         this.keyUpListeners.push(listener);
-    }
-
-    /**
-     * Adds a callback function to the list of callbacks invoked when a keyUp event occurs after a keyDown event.
-     * @param {function} listener the callback
-     */
-    addKeyPressListener(listener) {
-        this.keyPressListeners.push(listener);
     }
 
     /**
@@ -81,14 +72,9 @@ class Key {
      * Calls all of the registered keyUp listener callback functions.
      */
     fireKeyUp() {
-        this.isKeyDown = false;
-        this.keyUpListeners.forEach(listener => listener());
-    }
-
-    /**
-     * Calls all of the registered keyPress listener callback functions.
-     */
-    fireKeyPress() {
-        this.keyPressListeners.forEach(listener => listener());
+        if (this.isKeyDown) {
+            this.isKeyDown = false;
+            this.keyUpListeners.forEach(listener => listener());
+        }
     }
 }

--- a/initializeKeyMap.js
+++ b/initializeKeyMap.js
@@ -21,7 +21,7 @@ function initializeKeyMap(asteroids) {
     function createDrawDebugKey() {
         const key = new Key("D");
         key.shift = true;
-        key.addKeyDownListener(function () {
+        key.addKeyPressListener(function () {
             asteroids.toggleDrawDebug();
         });
         return key;
@@ -29,7 +29,7 @@ function initializeKeyMap(asteroids) {
 
     function createRequestFullScreenModeKey() {
         const key = new Key("f");
-        key.addKeyDownListener(function () {
+        key.addKeyPressListener(function () {
             asteroids.requestFullScreenMode();
         });
         return key;
@@ -38,7 +38,6 @@ function initializeKeyMap(asteroids) {
     function createHyperspaceKey() {
         const key = new Key("ArrowDown");
         key.addKeyDownListener(function () {
-            console.log("hyperspace");
             const ship = asteroids.ship;
             if (ship) {
                 ship.initiateHyperspace();
@@ -49,7 +48,7 @@ function initializeKeyMap(asteroids) {
 
     function createNewGameKey() {
         const key = new Key("s");
-        key.addKeyDownListener(function () {
+        key.addKeyPressListener(function () {
             asteroids.startNewGame();
         });
         return key;
@@ -76,7 +75,7 @@ function initializeKeyMap(asteroids) {
 
     function createShowDebugKey() {
         const key = new Key("d");
-        key.addKeyDownListener(function () {
+        key.addKeyPressListener(function () {
             asteroids.toggleShowDebug();
         });
         return key;

--- a/initializeKeyMap.js
+++ b/initializeKeyMap.js
@@ -21,7 +21,7 @@ function initializeKeyMap(asteroids) {
     function createDrawDebugKey() {
         const key = new Key("D");
         key.shift = true;
-        key.addKeyPressListener(function () {
+        key.addKeyDownListener(function () {
             asteroids.toggleDrawDebug();
         });
         return key;
@@ -29,7 +29,7 @@ function initializeKeyMap(asteroids) {
 
     function createRequestFullScreenModeKey() {
         const key = new Key("f");
-        key.addKeyPressListener(function () {
+        key.addKeyDownListener(function () {
             asteroids.requestFullScreenMode();
         });
         return key;
@@ -50,7 +50,7 @@ function initializeKeyMap(asteroids) {
 
     function createNewGameKey() {
         const key = new Key("s");
-        key.addKeyPressListener(function () {
+        key.addKeyUpListener(function () {
             if (!asteroids.paused) {
                 asteroids.startNewGame();
             }
@@ -81,7 +81,7 @@ function initializeKeyMap(asteroids) {
 
     function createShowDebugKey() {
         const key = new Key("d");
-        key.addKeyPressListener(function () {
+        key.addKeyDownListener(function () {
             asteroids.toggleShowDebug();
         });
         return key;

--- a/initializeKeyMap.js
+++ b/initializeKeyMap.js
@@ -38,9 +38,11 @@ function initializeKeyMap(asteroids) {
     function createHyperspaceKey() {
         const key = new Key("ArrowDown");
         key.addKeyDownListener(function () {
-            const ship = asteroids.ship;
-            if (ship) {
-                ship.initiateHyperspace();
+            if (!asteroids.paused) {
+                const ship = asteroids.ship;
+                if (ship) {
+                    ship.initiateHyperspace();
+                }
             }
         });
         return key;
@@ -49,7 +51,9 @@ function initializeKeyMap(asteroids) {
     function createNewGameKey() {
         const key = new Key("s");
         key.addKeyPressListener(function () {
-            asteroids.startNewGame();
+            if (!asteroids.paused) {
+                asteroids.startNewGame();
+            }
         });
         return key;
     }
@@ -65,9 +69,11 @@ function initializeKeyMap(asteroids) {
     function createShootKey() {
         const key = new Key(" ");
         key.addKeyDownListener(function () {
-            const ship = asteroids.ship;
-            if (ship) {
-                ship.shoot();
+            if (!asteroids.paused) {
+                const ship = asteroids.ship;
+                if (ship) {
+                    ship.shoot();
+                }
             }
         });
         return key;


### PR DESCRIPTION
* Fixed keyUp handling by ignoring the event unless the key is actually down
* fixed problems with key event handling that occurred while the game is paused 
* changed `Key.matches()` behavior so that modifiers are ignored for keyUp events - this prevents lockdown problems (e.g. ArrowLeft down, shift, ArrowLeft up leads to continuous left turn)